### PR TITLE
chore: dont tag task definition to fix ClientException: Tags can not be empty

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -76,6 +76,13 @@ func (r *Runner) Run(ctx context.Context) error {
 
 		log.Printf("found existing task definition %s", *describeTaskDefinitionOutput.TaskDefinition.TaskDefinitionArn)
 
+		// Adding logic to handle when the task definition returns empty array for tags which is causing woolies migrations to return
+		// ClientException: Tags can not be empty
+		tags := describeTaskDefinitionOutput.Tags
+        if len(tags) == 0 {
+            tags = nil
+        }
+
 		taskDefinitionInput = &ecs.RegisterTaskDefinitionInput{
 			ContainerDefinitions:    describeTaskDefinitionOutput.TaskDefinition.ContainerDefinitions,
 			Cpu:                     describeTaskDefinitionOutput.TaskDefinition.Cpu,
@@ -89,7 +96,7 @@ func (r *Runner) Run(ctx context.Context) error {
 			PlacementConstraints:    describeTaskDefinitionOutput.TaskDefinition.PlacementConstraints,
 			ProxyConfiguration:      describeTaskDefinitionOutput.TaskDefinition.ProxyConfiguration,
 			RequiresCompatibilities: describeTaskDefinitionOutput.TaskDefinition.RequiresCompatibilities,
-			Tags:                    describeTaskDefinitionOutput.Tags,
+			Tags:                    tags,
 			TaskRoleArn:             describeTaskDefinitionOutput.TaskDefinition.TaskRoleArn,
 			Volumes:                 describeTaskDefinitionOutput.TaskDefinition.Volumes,
 		}


### PR DESCRIPTION
We are getting `ClientException: Tags can not be empty` when trying to run a migrations task. This appears to fix the problem similar to what was done https://github.com/fabfuel/ecs-deploy/compare/1.10.3...1.10.5